### PR TITLE
inline private class constants

### DIFF
--- a/Test/Integration/Interception/Constants/ConstantsTest.php
+++ b/Test/Integration/Interception/Constants/ConstantsTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © 2020 Daniel Sloof. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Danslo\PrivateParts\Test\Integration\Interception\Constants;
+
+use Danslo\PrivateParts\Test\Integration\Interception\AbstractPlugin;
+use Danslo\PrivateParts\Test\Integration\Interception\Constants\Fixture\Intercepted;
+use Danslo\PrivateParts\Test\Integration\Interception\Constants\Fixture\Plugin;
+
+class ConstantsTest extends AbstractPlugin
+{
+    /**
+     * @var Intercepted
+     */
+    private $intercepted;
+
+    public function setUp(): void
+    {
+        $this->setUpInterceptionConfig(
+            [
+                Intercepted::class => [
+                    'plugins' => [
+                        'plugin' => [
+                            'instance' => Plugin::class
+                        ]
+                    ],
+                ]
+            ]
+        );
+
+        parent::setUp();
+
+        $this->intercepted = $this->_objectManager->create(Intercepted::class);
+    }
+
+    public function testCanGetInlinedIntConstant()
+    {
+        $this->assertEquals(1337, $this->intercepted->getIntConst());
+    }
+
+    public function testCanGetInlinedStringConstant()
+    {
+        $this->assertEquals('abc', $this->intercepted->getStringConst());
+    }
+
+    public function testCanGetInlinedArrayConstant()
+    {
+        $this->assertEquals([1, 3, 3, 7], $this->intercepted->getArrayConst());
+    }
+
+    public function testCanGetArrayElementByConstant()
+    {
+        $this->assertEquals(123, $this->intercepted->getArrayElementUsingConstant());
+        $this->assertEquals(123, $this->intercepted->getNestedArrayElementUsingDifferentConstants());
+    }
+}

--- a/Test/Integration/Interception/Constants/Fixture/Intercepted.php
+++ b/Test/Integration/Interception/Constants/Fixture/Intercepted.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Danslo\PrivateParts\Test\Integration\Interception\Constants\Fixture;
+
+class Intercepted
+{
+    private const PRIVATE_INT_CONST = 1337;
+    private const PRIVATE_STRING_CONST = 'abc';
+    private const PRIVATE_ARRAY_CONST = [1, 3, 3, 7];
+
+    private const SOME_ARRAY = [
+        self::PRIVATE_STRING_CONST => 123
+    ];
+
+    private const SOME_NESTED_ARRAY = [
+        self::PRIVATE_STRING_CONST => [
+            self::PRIVATE_STRING_CONST => [
+                self::PRIVATE_STRING_CONST => 123
+            ]
+        ]
+    ];
+
+    private function y(): void
+    {
+        return;
+    }
+
+    public function getIntConst(): int
+    {
+        $this->y(); // force inlining
+        return self::PRIVATE_INT_CONST;
+    }
+
+    public function getStringConst(): string
+    {
+        $this->y(); // force inlining
+        return self::PRIVATE_STRING_CONST;
+    }
+
+    public function getArrayConst(): array
+    {
+        $this->y(); // force inlining
+        return Intercepted::PRIVATE_ARRAY_CONST;
+    }
+
+    public function getArrayElementUsingConstant(): int
+    {
+        $this->y(); // force inlining
+        return Intercepted::SOME_ARRAY[self::PRIVATE_STRING_CONST];
+    }
+
+    public function getNestedArrayElementUsingDifferentConstants(): int
+    {
+        $this->y(); // force inlining
+        return Intercepted::SOME_NESTED_ARRAY
+            [self::PRIVATE_STRING_CONST]
+            [Intercepted::PRIVATE_STRING_CONST]
+            [\Danslo\PrivateParts\Test\Integration\Interception\Constants\Fixture\Intercepted::PRIVATE_STRING_CONST];
+    }
+}

--- a/Test/Integration/Interception/Constants/Fixture/Plugin.php
+++ b/Test/Integration/Interception/Constants/Fixture/Plugin.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Danslo\PrivateParts\Test\Integration\Interception\Constants\Fixture;
+
+class Plugin
+{
+    public function afterY(Intercepted $intercepted): void
+    {
+        return; // plugin is just here to run inlined code
+    }
+}


### PR DESCRIPTION
Original class:
```php
class Original
{
    private const PRIVATE_STRING_CONST = 'abc';
    private const SOME_ARRAY = [
        Original::PRIVATE_STRING_CONST => [
            Original::PRIVATE_STRING_CONST => [
                Original::PRIVATE_STRING_CONST => 123
            ]
        ]
    ];

    private function b() {}

    public function test()
    {
        $this->b();
        echo Original::SOME_ARRAY
            [Original::PRIVATE_STRING_CONST]
            [self::PRIVATE_STRING_CONST]
            [\Jh\PrivateInterceptor\Model\Original::PRIVATE_STRING_CONST];
    }
}
```

Generated code:
```php
...
    public function test()
    {
        $pluginInfo = $this->pluginList->getNext($this->subjectType, 'test');
        $parentCall = function () {
            if ($this->___isInlineCall(['b'])) {
                $this->b();
                echo ['abc' => ['abc' => ['abc' => 123]]]['abc']['abc']['abc'];
            } else {
                return $this->___callParent('test', []);
            }
        };
        if ($pluginInfo) {
            return $this->___callPlugins('test', [], $pluginInfo, $parentCall);
        } else {
            return $parentCall();
        }
    }
...
```